### PR TITLE
Fix #1: storage classes (functions and vars) are exposed and printed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,10 +5,16 @@
 - `Ast.character_kind` and `Ast.string_kind` are now distinct
   types (aliases for `Clang.clang_ext_characterkind` and
   `Clang.clang_ext_stringkind` respectively.
-  The constructor `Ordinary` replaced the former  constructor `Ascii`
+  The constructor `Ordinary` replaced the former constructor `Ascii`
   for `string_kind`, to match the new convention used by
   `clang::StringLiteral::StringKind` from Clang 15.0.0.
   The constructor `Ascii` for `character_kind` is left unchanged.
+
+- `Ast.Var` and `Ast.Function` constructors now have a `storage`
+  field in addition to the computed `linkage`, exposing the value
+  previously accessible via `cursor_get_storage_class`. The
+  storage classes are now correctly printed by the printer.
+  (reported by Ronan, rsaill/n47, https://github.com/thierry-martinez/clangml/issues/1)
 
 # 2022-08-09, 4.7.0
 

--- a/clangml/ast_sig.ml
+++ b/clangml/ast_sig.ml
@@ -65,11 +65,12 @@ module Ast : sig
   (** The following functions provides convenient ways to build some AST
       nodes. *)
 
-  val var : ?linkage:linkage_kind -> ?var_init:expr ->
+  val var : ?linkage:linkage_kind -> ?storage:storage_class -> ?var_init:expr ->
     ?constexpr:bool -> ?attributes:attribute list -> string -> qual_type ->
     var_decl_desc
 
-  val function_decl : ?linkage:linkage_kind -> ?body:stmt -> ?deleted:bool ->
+  val function_decl : ?linkage:linkage_kind -> ?storage:storage_class ->
+    ?body:stmt -> ?deleted:bool ->
     ?constexpr:bool -> ?inline_specified:bool -> ?inlined:bool ->
     ?nested_name_specifier:nested_name_specifier ->
     ?attributes:attribute list -> ?has_written_prototype:bool ->

--- a/clangml/clang.ml
+++ b/clangml/clang.ml
@@ -1014,7 +1014,7 @@ module Ast = struct
       let function_type = function_type_of_decl cursor in
       {
         linkage = get_cursor_linkage cursor;
-        storage = cursor_get_storage_class cursor;
+        storage = ext_decl_get_storage_class cursor;
         function_type;
         nested_name_specifier; name; body;
         deleted = ext_function_decl_is_deleted cursor;
@@ -1140,7 +1140,7 @@ module Ast = struct
 
     and var_decl_desc_of_cxcursor cursor =
       let linkage = get_cursor_linkage cursor in
-      let storage = cursor_get_storage_class cursor in
+      let storage = ext_decl_get_storage_class cursor in
       let var_name = get_cursor_spelling cursor in
       let var_type = of_type_loc (ext_declarator_decl_get_type_loc cursor) in
       let var_init : 'a option =

--- a/clangml/clang.ml
+++ b/clangml/clang.ml
@@ -170,16 +170,18 @@ module Ast = struct
     { decoration; desc }
 
   let var
-      ?(linkage = NoLinkage) ?var_init ?(constexpr = false)
+      ?(linkage = NoLinkage) ?(storage : storage_class = None) ?var_init
+      ?(constexpr = false)
       ?(attributes = []) var_name var_type =
-    { linkage; var_name; var_type; var_init; constexpr; attributes }
+    { linkage; storage; var_name; var_type; var_init; constexpr; attributes }
 
   let function_decl
-      ?(linkage = NoLinkage) ?body ?(deleted = false) ?(constexpr = false)
+      ?(linkage = NoLinkage) ?(storage : storage_class = None) ?body
+      ?(deleted = false) ?(constexpr = false)
       ?(inline_specified = false) ?(inlined = false) ?nested_name_specifier
       ?(attributes = []) ?(has_written_prototype = false)
       function_type name =
-    { linkage; body; deleted; constexpr; inline_specified; inlined;
+    { linkage; storage; body; deleted; constexpr; inline_specified; inlined;
       function_type; nested_name_specifier; name; attributes;
       has_written_prototype }
 
@@ -1012,6 +1014,7 @@ module Ast = struct
       let function_type = function_type_of_decl cursor in
       {
         linkage = get_cursor_linkage cursor;
+        storage = cursor_get_storage_class cursor;
         function_type;
         nested_name_specifier; name; body;
         deleted = ext_function_decl_is_deleted cursor;
@@ -1136,7 +1139,8 @@ module Ast = struct
       node ~cursor (Node.from_fun (fun () -> var_decl_desc_of_cxcursor cursor))
 
     and var_decl_desc_of_cxcursor cursor =
-      let linkage = cursor |> get_cursor_linkage in
+      let linkage = get_cursor_linkage cursor in
+      let storage = cursor_get_storage_class cursor in
       let var_name = get_cursor_spelling cursor in
       let var_type = of_type_loc (ext_declarator_decl_get_type_loc cursor) in
       let var_init : 'a option =
@@ -1147,7 +1151,7 @@ module Ast = struct
           end
         else
           None in
-      { linkage; var_name; var_type; var_init;
+      { linkage; storage; var_name; var_type; var_init;
         constexpr = ext_var_decl_is_constexpr cursor;
         attributes = attributes_of_decl cursor; }
 

--- a/clangml/clang__ast.ml
+++ b/clangml/clang__ast.ml
@@ -142,7 +142,7 @@ and calling_conv = cxcallingconv
 
 and linkage_kind = cxlinkagekind
 
-and storage_class = cx_storageclass
+and storage_class = clang_ext_storageclass
 
 and predefined_identifier_kind = clang_ext_predefinedexpr_identkind
 

--- a/clangml/clang__ast.ml
+++ b/clangml/clang__ast.ml
@@ -142,6 +142,8 @@ and calling_conv = cxcallingconv
 
 and linkage_kind = cxlinkagekind
 
+and storage_class = cx_storageclass
+
 and predefined_identifier_kind = clang_ext_predefinedexpr_identkind
 
 and lambda_capture_default = clang_ext_lambdacapturedefault
@@ -929,6 +931,7 @@ let () =
 
 and function_decl = {
     linkage : linkage_kind;
+    storage : storage_class;
     function_type : function_type;
     nested_name_specifier : nested_name_specifier option; (** C++ *)
     name : declaration_name;
@@ -2929,6 +2932,7 @@ let () =
   [%pattern?
     [{ desc = Function {
       linkage = External;
+      storage = None;
       function_type = {
         calling_conv = C;
         result = { desc = BuiltinType Void};
@@ -2989,6 +2993,7 @@ let () =
     [{ desc = RecordDecl { keyword = Struct; name = "T"; fields = [] }};
      { desc = Function {
       linkage = External;
+      storage = None;
       function_type = {
         calling_conv = C;
         result = { desc = BuiltinType Void};
@@ -3023,6 +3028,7 @@ let () =
   [%pattern?
     [{ desc = Function {
       linkage = External;
+      storage = None;
       function_type = {
         calling_conv = C;
         result = { desc = BuiltinType Void};
@@ -3058,6 +3064,7 @@ let () =
     [{ desc = RecordDecl { keyword = Struct; name = "T"; fields = [] }};
      { desc = Function {
       linkage = External;
+      storage = None;
       function_type = {
         calling_conv = C;
         result = { desc = BuiltinType Void};
@@ -3530,6 +3537,7 @@ let () =
   @@ fun ast -> match ast with
   | [{ desc = Function {
       linkage = External;
+      storage = None;
       function_type = {
         calling_conv = C;
         result = { desc = BuiltinType Int};
@@ -3546,6 +3554,7 @@ let () =
   fun ast -> match ast with
   | [{ desc = Function {
       linkage = Internal;
+      storage = Static;
       function_type = {
         calling_conv = C;
         result = { desc = BuiltinType Int};
@@ -3860,6 +3869,7 @@ let () =
     fun ast -> match ast with
   | [{ desc = Var {
       linkage = External;
+      storage = None;
       var_type = { const = false; desc = BuiltinType Int };
       var_name = "x";
       var_init = Some { desc = IntegerLiteral (Int 1)}}}] -> ()
@@ -3872,6 +3882,7 @@ let () =
     fun ast -> match ast with
   | [{ desc = Var {
       linkage = External;
+      storage = None;
       var_type = { const = true; desc = BuiltinType Int };
       var_name = "x";
       var_init = Some { desc = IntegerLiteral (Int 1)}}}] -> ()
@@ -3884,6 +3895,7 @@ let () =
     fun ast -> match ast with
   | [{ desc = Var {
       linkage = Internal;
+      storage = Static;
       var_type = { const = false; desc = BuiltinType Int };
       var_name = "x";
       var_init = Some ({ desc = IntegerLiteral (Int 1)})}}] -> ()
@@ -5225,6 +5237,7 @@ and var_decl = var_decl_desc node
 
 and var_decl_desc = {
     linkage : linkage_kind;
+    storage : storage_class;
     var_name : string;
     var_type : qual_type;
     var_init : expr option;

--- a/clangml/libclang_extensions.cpp
+++ b/clangml/libclang_extensions.cpp
@@ -4277,5 +4277,35 @@ extern "C" {
     return MakeTypeLocInvalid(tl.tu);
   }
 
+  enum clang_ext_StorageClass
+  clang_ext_Decl_getStorageClass(CXCursor cursor)
+  {
+    clang::StorageClass result = clang::StorageClass::SC_None;
+    if (auto d = GetCursorDecl(cursor)) {
+      if (auto vd = llvm::dyn_cast_or_null<clang::VarDecl>(d)) {
+        result = vd->getStorageClass();
+      }
+      else if (auto fd = llvm::dyn_cast_or_null<clang::FunctionDecl>(d)) {
+        result = fd->getStorageClass();
+      }
+    }
+    switch (result) {
+    case clang::StorageClass::SC_Extern:
+      return CLANG_EXT_SC_Extern;
+    case clang::StorageClass::SC_Static:
+      return CLANG_EXT_SC_Static;
+    case clang::StorageClass::SC_PrivateExtern:
+      return CLANG_EXT_SC_PrivateExtern;
+    #ifdef LLVM_VERSION_BEFORE_3_8_0
+    case clang::StorageClass::SC_OpenCLWorkGroupLocal:
+      return CLANG_EXT_SC_OpenCLWorkGroupLocal;
+    #endif
+    case clang::StorageClass::SC_Auto:
+      return CLANG_EXT_SC_Auto;
+    case clang::StorageClass::SC_Register:
+      return CLANG_EXT_SC_Register;
+    }
+    return CLANG_EXT_SC_None;
+  }
   #include "libclang_extensions_attrs.inc"
 }

--- a/clangml/libclang_extensions.h
+++ b/clangml/libclang_extensions.h
@@ -1359,4 +1359,18 @@ clang_ext_TypeOfType_getUnderlyingType(CXType);
 struct clang_ext_TypeLoc
 clang_ext_TypeOfTypeLoc_getUnderlyingType(struct clang_ext_TypeLoc);
 
+enum clang_ext_StorageClass {
+  CLANG_EXT_SC_None,
+  CLANG_EXT_SC_Extern,
+  CLANG_EXT_SC_Static,
+  CLANG_EXT_SC_PrivateExtern,
+  CLANG_EXT_SC_OpenCLWorkGroupLocal, /* only with Clang 3.{4,5,6,7} */
+  CLANG_EXT_SC_Auto,
+  CLANG_EXT_SC_Register
+};
+
+/* clang_Cursor_getStorageClass is not available with Clang 3.{4,5} */
+enum clang_ext_StorageClass
+clang_ext_Decl_getStorageClass(CXCursor);
+
 #include "libclang_extensions_attrs_headers.inc"

--- a/clangml/printer.ml
+++ b/clangml/printer.ml
@@ -378,14 +378,14 @@ module Make (Node : Clang__ast.NodeS) = struct
     | Some else_branch ->
         Format.fprintf fmt "@[else@ %a@]" stmt else_branch
 
-  and pp_storage fmt (storage : Clang__bindings.cx_storageclass) =
+  and pp_storage fmt (storage : Clang__ast.storage_class) =
     match storage with
     | None -> ()
     | Extern -> Format.fprintf fmt "extern@ "
     | Static -> Format.fprintf fmt "static@ "
     | _ ->
         failwith (Format.asprintf "Not implemented storage: %a"
-          (Refl.pp [%refl: Clang__bindings.cx_storageclass] []) storage)
+          (Refl.pp [%refl: Clang__ast.storage_class] []) storage)
 
   and pp_parameters fmt parameters =
     let all_parameters = List.map Option.some parameters.non_variadic in


### PR DESCRIPTION
Reported by Ronan, rsaill/n47, https://github.com/thierry-martinez/clangml/issues/1