### PR TITLE
Fix #3: integer literal printing and radix parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,11 +10,16 @@
   `clang::StringLiteral::StringKind` from Clang 15.0.0.
   The constructor `Ascii` for `character_kind` is left unchanged.
 
-- `Ast.Var` and `Ast.Function` constructors now have a `storage`
+- #1, #2: `Ast.Var` and `Ast.Function` constructors now have a `storage`
   field in addition to the computed `linkage`, exposing the value
   previously accessible via `cursor_get_storage_class`. The
   storage classes are now correctly printed by the printer.
   (reported by Ronan, rsaill/n47, https://github.com/thierry-martinez/clangml/issues/1)
+
+- #3, #4: fix `Clang.Expr.radix_of_integer_literal` when the literal
+  comes from a macro expansion, and fix printing of unsigned/long
+  integer literals with `Clang.Printer`.
+  (reported by Ronan, rsaill/n47, https://github.com/thierry-martinez/clangml/issues/3)
 
 # 2022-08-09, 4.7.0
 

--- a/clangml/clang.ml
+++ b/clangml/clang.ml
@@ -2222,11 +2222,14 @@ module Expr = [%meta node_module [%str
       Decimal
 
   let radix_of_integer_literal (expr : t) : radix option =
-    let tokens = Ast.tokens_of_node expr in
+    let cursor = Ast.cursor_of_node expr in
+    let start = get_range_start (get_cursor_extent cursor) in
+    let tu = cursor_get_translation_unit cursor in
+    let tokens = tokenize tu (get_range start start) in
     (* [tokens] should be an array of length 1: however, with Clang <7,
        [tokens] include the token next to the range. *)
     if Array.length tokens >= 1 then
-      Some (radix_of_string tokens.(0))
+      Some (radix_of_string (get_token_spelling tu tokens.(0)))
     else
       None
 


### PR DESCRIPTION
rsaill reported that

```
const unsigned long x = 18446744073709551615UL;
```

was printed as follows with `Clang.Printer`:

```
unsigned long const x = -1;
```

The printer now uses the signedness information to print integer
literals.

Moreover, `Clang.Expr.radix_of_integer_literal` did not work if the
literal was defined in a macro: this is now fixed.